### PR TITLE
Fix lint error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,18 +54,18 @@ ignore = [
   "D213", # multi-line-summary-second-line (conflicts with "D212": multi-line-summary-first-line)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# Ignore all .py files starting with test_.
+"test_*.py" = [
+  "D102", # undocumented-public-method
+]
+
 [tool.ruff.lint.isort]
 combine-as-imports = true
 # If a class or a top-level function directly following imports, there will be two blank lines.
 # If global variables directly following imports, by default there will only be one blank line.
 # PEP 8 leaves it up to our discretion to decide what is best here.
 lines-after-imports = 2
-
-[tool.ruff.lint.per-file-ignores]
-# Ignore all .py files starting with test_.
-"test_*.py" = [
-  "D102", # undocumented-public-method
-]
 
 
 # pyright


### PR DESCRIPTION
Fixes the following `ruff` error:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```