### PR TITLE
Execute strategy before checking if

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,16 +183,16 @@ jobs:
       - determine-which-jobs
       - check-style-jinja
       - check-types
-    if: |
-      needs.determine-which-jobs.outputs.check-tests == 'true' &&
-      needs.check-style-jinja.result != 'failure' &&
-      needs.check-types.result != 'failure'
     strategy:
       matrix:
         include:
           - { name: 🐧 ubuntu, os: ubuntu-latest }
           - { name: 🖼️ windows, os: windows-latest }
           - { name: 🍏 macos, os: macos-latest }
+    if: |
+      needs.determine-which-jobs.outputs.check-tests == 'true' &&
+      needs.check-style-jinja.result != 'failure' &&
+      needs.check-types.result != 'failure'
     steps:
       # Setup
       - name: 🛒 Checkout repo


### PR DESCRIPTION
This ensures that the separate jobs show up as skipped when they don't run (rather than "check-test / {{ matrix.name }}"