### PR TITLE
Store leaderboard data as readable json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
     name: 🔮 determine-which-jobs / 🐧 ubuntu
     runs-on: ubuntu-latest
     outputs:
+      ensure-no-leaderboard-data: ${{ steps.ensure-no-leaderboard-data.outputs.changed }}
       check-style-prettier: ${{ steps.check-style-prettier.outputs.changed }}
       check-style-css: ${{ steps.check-style-css.outputs.changed }}
       check-style-jijna: ${{ steps.check-style-jinja.outputs.changed }}
@@ -30,6 +31,13 @@ jobs:
         with:
           fetch-depth: 0
       # Determine which jobs need to be run based on which files have changed
+      # no leaderboard data
+      - name: 🙅 Determine ensure-no-leaderboard-data
+        id: ensure-no-leaderboard-data
+        uses: ./.github/actions/check-dependencies-changed
+        with:
+          pathspec: |-
+            'leaderboard_data/*' \
       # formatting (css, json, md, yaml)
       - name: 🧚 Determine check-style-prettier
         id: check-style-prettier
@@ -119,6 +127,18 @@ jobs:
             '**/*.py' \
             'requirements/leaderboard.txt' \
             '.coveragerc' \
+
+  # Ensure no leaderboard data is added
+  ensure-no-leaderboard-data:
+    name: 🙅 ensure-no-leaderboard-data / 🐧 ubuntu
+    runs-on: ubuntu-latest
+    needs: determine-which-jobs
+    if: needs.determine-which-jobs.outputs.ensure-no-leaderboard-data == 'true'
+    steps:
+      - name: 🚱 Fail due to leaderboard data
+        run: |
+          echo "Leaderboard data should not be added to this branch"
+          exit 1
 
   # Check formatting (css, json, md, yaml)
   check-style-prettier:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,10 +135,20 @@ jobs:
     needs: determine-which-jobs
     if: needs.determine-which-jobs.outputs.ensure-no-leaderboard-data == 'true'
     steps:
-      - name: 🚱 Fail due to leaderboard data
+      # Setup
+      - name: 🛒 Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Recheck the diff - this is done because this job will run if the ci has changed
+      - name: 🚱 Check no leaderboard data
         run: |
-          echo "Leaderboard data should not be added to this branch"
-          exit 1
+          if git diff --quiet origin/main...HEAD -- 'leaderboard_data/*'; then
+            echo "No leaderboard data found"
+          else
+            echo "Leaderboard data should not be added to this branch"
+            exit 1
+          fi
 
   # Check formatting (css, json, md, yaml)
   check-style-prettier:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
         with:
           fetch-depth: 0
       # Recheck the diff - this is done because this job will run if the ci has changed
-      - name: 🚱 Check no leaderboard data
+      - name: 🚱 Ensure no leaderboard data
         run: |
           if git diff --quiet origin/main...HEAD -- 'leaderboard_data/*'; then
             echo "No leaderboard data found"

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,5 @@
 # ...
 # generated lock files
 package-lock.json
+# generated leaderboard data
+leaderboard_data/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,5 +12,5 @@
 # ... but make sure to check subdirectories (otherwise this doesn't work).
 !*/
 # ...
-# Ignore machine-generated lock files
+# generated lock files
 package-lock.json

--- a/leaderboard_html/css/style.css
+++ b/leaderboard_html/css/style.css
@@ -87,8 +87,7 @@ main {
   min-width: 1000px;
   /* large top and bottom margin to be clear of the header and footer */
   margin: 24px auto 60px;
-  padding: 20px;
-  padding-top: 10px;
+  padding: 10px 20px 20px;
   border-radius: 5px;
   /* Look slightly 3d */
   box-shadow: 0 5px 5px rgb(0 0 0 / 10%);

--- a/leaderboard_html/css/style.css
+++ b/leaderboard_html/css/style.css
@@ -33,17 +33,17 @@ footer {
   font-size: 0.8em;
 }
 
-/* No underline for any links by default */
-a {
-  text-decoration: none;
-}
-
 /* Nav links wrap when the page is narrow */
 nav {
   display: flex;
   flex-flow: wrap;
   row-gap: 4px;
   justify-content: center;
+}
+
+/* No underline for any links by default */
+a {
+  text-decoration: none;
 }
 
 /* Header nav links look like buttons */

--- a/leaderboard_html/css/style.css
+++ b/leaderboard_html/css/style.css
@@ -93,6 +93,7 @@ main {
   box-shadow: 0 5px 5px rgb(0 0 0 / 10%);
 }
 
+/* The heading contains the page's title */
 h1 {
   text-align: center;
   padding-bottom: 10px;

--- a/leaderboard_html/css/style.css
+++ b/leaderboard_html/css/style.css
@@ -20,8 +20,9 @@ footer {
 
 /* The header is fixed to the top */
 header {
-  position: fixed;
+  position: sticky;
   top: 0;
+  min-width: 1040px;
 }
 
 /* The footer is fixed to the bottom */
@@ -37,6 +38,13 @@ a {
   text-decoration: none;
 }
 
+/* Nav links wrap when the page is narrow */
+nav {
+  display: flex;
+  flex-flow: wrap;
+  justify-content: center;
+}
+
 /* Header nav links look like buttons */
 nav a {
   color: white;
@@ -45,6 +53,7 @@ nav a {
   margin: 0 5px;
   padding: 8px 16px;
   border-radius: 5px;
+  box-sizing: border-box;
 }
 
 /* Footer links */
@@ -77,7 +86,7 @@ main {
   width: 80%;
   min-width: 1000px;
   /* large top and bottom margin to be clear of the header and footer */
-  margin: 60px auto;
+  margin: 24px auto 60px;
   padding: 20px;
   padding-top: 10px;
   border-radius: 5px;

--- a/leaderboard_html/css/style.css
+++ b/leaderboard_html/css/style.css
@@ -42,6 +42,7 @@ a {
 nav {
   display: flex;
   flex-flow: wrap;
+  row-gap: 4px;
   justify-content: center;
 }
 
@@ -50,7 +51,7 @@ nav a {
   color: white;
   /* Fade in and out */
   transition: background-color 0.3s;
-  margin: 0 5px;
+  margin: 0 2px;
   padding: 8px 16px;
   border-radius: 5px;
   box-sizing: border-box;

--- a/src/leaderboard/data/data_generator.py
+++ b/src/leaderboard/data/data_generator.py
@@ -15,8 +15,8 @@ from src.leaderboard.li.pert_type import PerfType
 
 def load_bot_profiles(file_system: FileSystem) -> dict[str, BotProfile]:
   """Load the known bot profiles."""
-  ndjson = file_system.load_file_lines(file_paths.bot_profiles_path())
-  bot_profiles = [BotProfile.from_json(json_line) for json_line in ndjson]
+  ndjson = file_system.read_file(file_paths.bot_profiles_path())
+  bot_profiles = [BotProfile.from_json(json_line) for json_line in ndjson.split("\n")] if ndjson else []
   return {bot_profile.name: bot_profile for bot_profile in bot_profiles}
 
 
@@ -24,8 +24,10 @@ def load_leaderboard_rows(file_system: FileSystem) -> dict[PerfType, list[Leader
   """Load the previous leaderboard rows and return lists of leaderboard rows grouped by perf type."""
   previous_rows_by_perf_type: dict[PerfType, list[LeaderboardRow]] = {}
   for perf_type in PerfType.all_except_unknown():
-    ndjson = file_system.load_file_lines(file_paths.data_path(perf_type))
-    previous_rows_by_perf_type[perf_type] = [LeaderboardRow.from_json(json_line) for json_line in ndjson]
+    ndjson = file_system.read_file(file_paths.data_path(perf_type))
+    previous_rows_by_perf_type[perf_type] = (
+      [LeaderboardRow.from_json(json_line) for json_line in ndjson.split("\n")] if ndjson else []
+    )
   return previous_rows_by_perf_type
 
 

--- a/src/leaderboard/data/data_generator.py
+++ b/src/leaderboard/data/data_generator.py
@@ -164,7 +164,7 @@ class LeaderboardDataResult:
 
   def get_bot_profiles_sorted(self) -> list[BotProfile]:
     """Return the bot profiles dict sorted by name."""
-    return list(sorted(self.bot_profiles_by_name.values(), key=lambda profile: name_sort_key(profile.name)))
+    return sorted(self.bot_profiles_by_name.values(), key=lambda profile: name_sort_key(profile.name))
 
   def get_ranked_rows_sorted(self) -> dict[PerfType, list[LeaderboardRow]]:
     """Return the ranked rows by perf type with the ranked rows sorted by name."""

--- a/src/leaderboard/data/data_generator.py
+++ b/src/leaderboard/data/data_generator.py
@@ -54,9 +54,14 @@ def get_online_bot_info(lichess_client: LichessClient) -> BotInfoResult:
   bot_perfs_by_perf_type: dict[PerfType, list[BotPerf]] = defaultdict(list)
   for bot_json in lichess_client.get_online_bots().splitlines():
     bot_user = BotUser.from_json(bot_json)
-    bot_profiles_by_name[bot_user.username] = BotProfile.from_bot_user(bot_user)
+    has_played_games = False
     for perf in bot_user.perfs:
-      bot_perfs_by_perf_type[perf.perf_type].append(BotPerf(bot_user.username, LeaderboardPerf.from_perf(perf)))
+      if perf.games:
+        has_played_games = True
+        bot_perf = BotPerf(bot_user.username, LeaderboardPerf.from_perf(perf))
+        bot_perfs_by_perf_type[perf.perf_type].append(bot_perf)
+    if has_played_games:
+      bot_profiles_by_name[bot_user.username] = BotProfile.from_bot_user(bot_user)
   return BotInfoResult(bot_profiles_by_name, bot_perfs_by_perf_type)
 
 

--- a/src/leaderboard/data/data_generator.py
+++ b/src/leaderboard/data/data_generator.py
@@ -128,6 +128,14 @@ def create_ranked_rows(
   return new_rows
 
 
+def name_sort_key(name: str) -> tuple[str, str]:
+  """Return a key for sorting by name: (name.lower(), name).
+
+  The secondary sort is incase two bots can have the same name but with different capitalization.
+  """
+  return (name.lower(), name)
+
+
 @dataclasses.dataclass(frozen=True)
 class LeaderboardDataResult:
   """The result of generating the leaderboard data.
@@ -149,13 +157,13 @@ class LeaderboardDataResult:
 
   def get_bot_profiles_sorted(self) -> list[BotProfile]:
     """Return the bot profiles dict sorted by name."""
-    return list(sorted(self.bot_profiles_by_name.values(), key=lambda profile: profile.name.lower()))
+    return list(sorted(self.bot_profiles_by_name.values(), key=lambda profile: name_sort_key(profile.name)))
 
   def get_ranked_rows_sorted(self) -> dict[PerfType, list[LeaderboardRow]]:
     """Return the ranked rows by perf type with the ranked rows sorted by name."""
     sorted_ranked_rows: dict[PerfType, list[LeaderboardRow]] = {}
     for perf_type, ranked_rows in self.ranked_rows_by_perf_type.items():
-      sorted_ranked_rows[perf_type] = sorted(ranked_rows, key=lambda row: row.name.lower())
+      sorted_ranked_rows[perf_type] = sorted(ranked_rows, key=lambda row: name_sort_key(row.name))
     return sorted_ranked_rows
 
 

--- a/src/leaderboard/data/leaderboard_objects.py
+++ b/src/leaderboard/data/leaderboard_objects.py
@@ -1,7 +1,6 @@
 """Dataclasses related rows in a leaderboard."""
 
 import dataclasses
-import json
 from typing import Any
 
 from src.leaderboard.chrono.durations import TWO_WEEKS
@@ -56,15 +55,7 @@ class BotProfile:
     )
 
   @classmethod
-  def from_json(cls, json_str: str) -> "BotProfile":
-    """Create a BotProfile from json.
-
-    The bot will be assumed not to be new and to be offline.
-    """
-    return BotProfile.from_json_dict(json.loads(json_str))
-
-  @classmethod
-  def from_json_dict(cls, json_dict: dict[str, Any]) -> "BotProfile":
+  def from_dict(cls, json_dict: dict[str, Any]) -> "BotProfile":
     """Create a BotProfile from a json dict.
 
     The bot will be assumed not to be new and to be offline.
@@ -105,12 +96,12 @@ class BotProfile:
     seen_in_last_two_weeks = current_time - self.last_seen <= TWO_WEEKS
     return not self.tos_violation and seen_in_last_two_weeks
 
-  def to_json(self) -> str:
-    """Convert the BotProfile to json.
+  def as_dict(self) -> dict[str, Any]:
+    """Return the BotProfile represented as a dict.
 
     Values will only be set if they are not equal to their default values.
     """
-    return json.dumps(default_remover.to_dict_without_defaults(dataclasses.asdict(self)))
+    return default_remover.to_dict_without_defaults(dataclasses.asdict(self))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -137,7 +128,7 @@ class LeaderboardPerf:
     return LeaderboardPerf(perf.rating, perf.rd, perf.prog, perf.games, perf.prov)
 
   @classmethod
-  def from_json_dict(cls, json_dict: dict[str, Any]) -> "LeaderboardPerf":
+  def from_dict(cls, json_dict: dict[str, Any]) -> "LeaderboardPerf":
     """Create a LeaderboardPerf from a json dict."""
     return LeaderboardPerf(
       json_dict.get("rating", 0),
@@ -177,7 +168,7 @@ class RankInfo:
   last_played: int
 
   @classmethod
-  def from_json_dict(cls, json_dict: dict[str, Any]) -> "RankInfo":
+  def from_dict(cls, json_dict: dict[str, Any]) -> "RankInfo":
     """Create a RankInfo from a json dict."""
     return RankInfo(
       json_dict.get("rank", 0),
@@ -202,18 +193,17 @@ class LeaderboardRow:
   rank_info: RankInfo
 
   @classmethod
-  def from_json(cls, json_str: str) -> "LeaderboardRow":
-    """Create a LeaderboardRow from json."""
-    json_dict = json.loads(json_str)
+  def from_dict(cls, json_dict: dict[str, Any]) -> "LeaderboardRow":
+    """Create a LeaderboardRow from a json dict."""
     return LeaderboardRow(
       json_dict.get("name", ""),
-      LeaderboardPerf.from_json_dict(json_dict.get("perf", {})),
-      RankInfo.from_json_dict(json_dict.get("rank_info", {})),
+      LeaderboardPerf.from_dict(json_dict.get("perf", {})),
+      RankInfo.from_dict(json_dict.get("rank_info", {})),
     )
 
-  def to_json(self) -> str:
-    """Convert the leaderboard row to json.
+  def as_dict(self) -> dict[str, Any]:
+    """Return the LeaderboardRow represented as a dict.
 
     Values will only be set if they are not equal to their default values.
     """
-    return json.dumps(default_remover.to_dict_without_defaults(dataclasses.asdict(self)))
+    return default_remover.to_dict_without_defaults(dataclasses.asdict(self))

--- a/src/leaderboard/fs/file_paths.py
+++ b/src/leaderboard/fs/file_paths.py
@@ -4,13 +4,13 @@ from src.leaderboard.li.pert_type import PerfType
 
 
 def bot_profiles_path() -> str:
-  """Return "leaderboard_data/bot_profiles.ndjson"."""
-  return "leaderboard_data/bot_profiles.ndjson"
+  """Return "leaderboard_data/bot_profiles.json"."""
+  return "leaderboard_data/bot_profiles.json"
 
 
 def data_path(perf_type: PerfType) -> str:
-  """Return "leaderboard_data/{perf_type.to_string()}.ndjson"."""
-  return f"leaderboard_data/{perf_type.to_string()}.ndjson"
+  """Return "leaderboard_data/{perf_type.to_string()}.json"."""
+  return f"leaderboard_data/{perf_type.to_string()}.json"
 
 
 def html_path(name: str) -> str:

--- a/src/leaderboard/fs/file_paths.py
+++ b/src/leaderboard/fs/file_paths.py
@@ -3,14 +3,17 @@
 from src.leaderboard.li.pert_type import PerfType
 
 
+LEADERBOARD_DATA_DIR = "leaderboard_data"
+
+
 def bot_profiles_path() -> str:
   """Return "leaderboard_data/bot_profiles.json"."""
-  return "leaderboard_data/bot_profiles.json"
+  return f"{LEADERBOARD_DATA_DIR}/bot_profiles.json"
 
 
 def data_path(perf_type: PerfType) -> str:
   """Return "leaderboard_data/{perf_type.to_string()}.json"."""
-  return f"leaderboard_data/{perf_type.to_string()}.json"
+  return f"{LEADERBOARD_DATA_DIR}/{perf_type.to_string()}.json"
 
 
 def html_path(name: str) -> str:

--- a/src/leaderboard/fs/file_paths.py
+++ b/src/leaderboard/fs/file_paths.py
@@ -16,6 +16,11 @@ def data_path(perf_type: PerfType) -> str:
   return f"{LEADERBOARD_DATA_DIR}/{perf_type.to_string()}.json"
 
 
+def generation_number_path() -> str:
+  """Return "leaderboard_data/generation_number.txt"."""
+  return f"{LEADERBOARD_DATA_DIR}/generation_number.txt"
+
+
 def html_path(name: str) -> str:
   """Return "leaderboard_html/{name}.html"."""
   return f"leaderboard_html/{name}.html"

--- a/src/leaderboard/fs/file_system.py
+++ b/src/leaderboard/fs/file_system.py
@@ -7,11 +7,11 @@ class FileSystem(abc.ABC):
   """Interface for interacting with a file system."""
 
   @abc.abstractmethod
-  def load_file_lines(self, file_name: str) -> list[str]:
-    """Load and return all of the lines in a file."""
+  def read_file(self, file_name: str) -> str | None:
+    """Load and return all of the contents of a file."""
     ...
 
   @abc.abstractmethod
-  def save_file_lines(self, file_name: str, file_lines: list[str]) -> None:
-    """Save all of the lines to a file."""
+  def write_file(self, file_name: str, file_contents: str) -> None:
+    """Save the contents to a file."""
     ...

--- a/src/leaderboard/fs/real_file_system.py
+++ b/src/leaderboard/fs/real_file_system.py
@@ -8,17 +8,17 @@ from src.leaderboard.fs.file_system import FileSystem
 class RealFileSystem(FileSystem):
   """Read and write files from disk."""
 
-  def load_file_lines(self, file_name: str) -> list[str]:
-    """Load and return all of the lines in a file."""
+  def read_file(self, file_name: str) -> str | None:
+    """Load and return all of the contents of a file."""
     path = Path(file_name)
     if not path.exists():
-      return []
+      return None
     with path.open() as file:
-      return [line.strip("\n") for line in file.readlines()]
+      return file.read()
 
-  def save_file_lines(self, file_name: str, file_lines: list[str]) -> None:
-    """Save all of the lines to a file."""
+  def write_file(self, file_name: str, file_contents: str) -> None:
+    """Save the contents to a file."""
     path = Path(file_name)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as file:
-      file.writelines([f"{line}\n" for line in file_lines])
+      file.write(file_contents)

--- a/src/leaderboard/main/leaderboard_generator.py
+++ b/src/leaderboard/main/leaderboard_generator.py
@@ -12,6 +12,13 @@ from src.leaderboard.log.log_writer import LogWriter
 from src.leaderboard.page.html_generator import HtmlGenerator
 
 
+def increment_generation_number(file_system: FileSystem) -> None:
+  """Increments the value generation number number file."""
+  value_str = file_system.read_file(file_paths.generation_number_path())
+  value = int(value_str) if value_str else 0
+  file_system.write_file(file_paths.generation_number_path(), str(value + 1))
+
+
 class LeaderboardGenerator:
   """Generator of leaderboards."""
 
@@ -48,6 +55,9 @@ class LeaderboardGenerator:
     # Save the leaderboard html
     for name, html in html_by_name.items():
       self.file_system.write_file(file_paths.html_path(name), html)
+
+    # Make note of how many times we have generated the leaderboards
+    increment_generation_number(self.file_system)
 
     # Print time elapsed
     time_elapsed = time.time() - start_time

--- a/src/leaderboard/main/leaderboard_generator.py
+++ b/src/leaderboard/main/leaderboard_generator.py
@@ -1,5 +1,6 @@
 """Leaderboard generator."""
 
+import json
 import time
 
 from src.leaderboard.chrono.time_provider import TimeProvider
@@ -34,10 +35,11 @@ class LeaderboardGenerator:
     leaderboard_data = data_generator.generate_leaderboard_data()
 
     # Save the leaderboard data
-    bot_profiles = [profile.to_json() for profile in leaderboard_data.get_bot_profiles_sorted().values()]
-    self.file_system.write_file(file_paths.bot_profiles_path(), "\n".join(bot_profiles))
+    bot_profile_dicts = [bot_profile.as_dict() for bot_profile in leaderboard_data.get_bot_profiles_sorted()]
+    self.file_system.write_file(file_paths.bot_profiles_path(), json.dumps(bot_profile_dicts, indent=2))
     for perf_type, rows in leaderboard_data.get_ranked_rows_sorted().items():
-      self.file_system.write_file(file_paths.data_path(perf_type), "\n".join([row.to_json() for row in rows]))
+      row_dicts = [row.as_dict() for row in rows]
+      self.file_system.write_file(file_paths.data_path(perf_type), json.dumps(row_dicts, indent=2))
 
     # Generate leaderboard html
     html_generator = HtmlGenerator(self.time_provider)

--- a/src/leaderboard/main/leaderboard_generator.py
+++ b/src/leaderboard/main/leaderboard_generator.py
@@ -35,9 +35,9 @@ class LeaderboardGenerator:
 
     # Save the leaderboard data
     bot_profiles = [profile.to_json() for profile in leaderboard_data.get_bot_profiles_sorted().values()]
-    self.file_system.save_file_lines(file_paths.bot_profiles_path(), bot_profiles)
+    self.file_system.write_file(file_paths.bot_profiles_path(), "\n".join(bot_profiles))
     for perf_type, rows in leaderboard_data.get_ranked_rows_sorted().items():
-      self.file_system.save_file_lines(file_paths.data_path(perf_type), [row.to_json() for row in rows])
+      self.file_system.write_file(file_paths.data_path(perf_type), "\n".join([row.to_json() for row in rows]))
 
     # Generate leaderboard html
     html_generator = HtmlGenerator(self.time_provider)
@@ -45,7 +45,7 @@ class LeaderboardGenerator:
 
     # Save the leaderboard html
     for name, html in html_by_name.items():
-      self.file_system.save_file_lines(file_paths.html_path(name), [html])
+      self.file_system.write_file(file_paths.html_path(name), html)
 
     # Print time elapsed
     time_elapsed = time.time() - start_time

--- a/src/leaderboard/main/leaderboard_generator.py
+++ b/src/leaderboard/main/leaderboard_generator.py
@@ -35,7 +35,7 @@ class LeaderboardGenerator:
     """Generate the leaderboards."""
     # Start timer
     start_time = time.time()
-    self.log_writer.info("Generating leaderboard...")
+    self.log_writer.info("Generating leaderboards...")
 
     # Generate leaderboard data
     data_generator = DataGenerator(self.file_system, self.lichess_client, self.time_provider)

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -113,7 +113,7 @@ class TestDataGeneratorFunctions(unittest.TestCase):
   def test_load_bot_profiles(self) -> None:
     file_system = InMemoryFileSystem()
     bot_profiles = [BOT_1_CURRENT_PROFILE.to_json(), BOT_2_CURRENT_PROFILE.to_json()]
-    file_system.save_file_lines(file_paths.bot_profiles_path(), bot_profiles)
+    file_system.write_file(file_paths.bot_profiles_path(), "\n".join(bot_profiles))
     # When loading the bot profiles new and online are set to false
     expected_bot_profiles = {
       "Bot-1": BotProfile("Bot-1", "flair", "_earth", DATE_2024_04_01, DATE_2025_04_01, True, False, False, False),
@@ -131,8 +131,8 @@ class TestDataGeneratorFunctions(unittest.TestCase):
     file_system = InMemoryFileSystem()
     bullet_leaderboard = [BOT_1_ROW_BULLET.to_json(), BOT_2_ROW_BULLET.to_json()]
     blitz_leaderboard = [BOT_2_ROW_BLITZ.to_json(), BOT_1_ROW_BLITZ.to_json()]
-    file_system.save_file_lines(file_paths.data_path(PerfType.BULLET), bullet_leaderboard)
-    file_system.save_file_lines(file_paths.data_path(PerfType.BLITZ), blitz_leaderboard)
+    file_system.write_file(file_paths.data_path(PerfType.BULLET), "\n".join(bullet_leaderboard))
+    file_system.write_file(file_paths.data_path(PerfType.BLITZ), "\n".join(blitz_leaderboard))
     previous_rows_by_perf_type = data_generator_functions.load_leaderboard_rows(file_system)
     self.assertEqual(len(previous_rows_by_perf_type), 13)
     self.assertListEqual(previous_rows_by_perf_type[PerfType.BULLET], [BOT_1_ROW_BULLET, BOT_2_ROW_BULLET])
@@ -254,10 +254,10 @@ class TestDataGenerator(unittest.TestCase):
     file_system = InMemoryFileSystem()
 
     bullet_ndjson = [BOT_1_ROW_BULLET.to_json(), BOT_2_ROW_BULLET.to_json()]
-    file_system.save_file_lines(file_paths.data_path(PerfType.BULLET), bullet_ndjson)
+    file_system.write_file(file_paths.data_path(PerfType.BULLET), "\n".join(bullet_ndjson))
 
     bot_profiles_json = [BOT_1_PROFILE.to_json(), BOT_2_PROFILE.to_json()]
-    file_system.save_file_lines(file_paths.bot_profiles_path(), bot_profiles_json)
+    file_system.write_file(file_paths.bot_profiles_path(), "\n".join(bot_profiles_json))
 
     lichess_client = FakeLichessClient()
     lichess_client.set_online_bots("\n".join([remove_whitespace(BOT_1_CURRENT_JSON), remove_whitespace(BOT_2_CURRENT_JSON)]))

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -144,11 +144,11 @@ class TestDataGeneratorFunctions(unittest.TestCase):
     lichess_client.set_online_bots("\n".join([remove_whitespace(BOT_1_CURRENT_JSON), remove_whitespace(BOT_2_CURRENT_JSON)]))
     bot_info = data_generator_functions.get_online_bot_info(lichess_client)
     self.assertDictEqual(bot_info.bot_profiles_by_name, {"Bot-1": BOT_1_CURRENT_PROFILE, "Bot-2": BOT_2_CURRENT_PROFILE})
-    self.assertEqual(len(bot_info.bot_perfs_by_perf_type), 2)
-    self.assertListEqual(
-      bot_info.bot_perfs_by_perf_type[PerfType.BULLET], [BOT_1_CURRENT_PERF_BULLET, BOT_2_CURRENT_PERF_BULLET]
-    )
-    self.assertListEqual(bot_info.bot_perfs_by_perf_type[PerfType.BLITZ], [BOT_1_CURRENT_PERF_BLITZ, BOT_2_CURRENT_PERF_BLITZ])
+    expected_bot_perfs_by_perf_type = {
+      PerfType.BULLET: [BOT_1_CURRENT_PERF_BULLET, BOT_2_CURRENT_PERF_BULLET],
+      PerfType.BLITZ: [BOT_1_CURRENT_PERF_BLITZ, BOT_2_CURRENT_PERF_BLITZ],
+    }
+    self.assertDictEqual(bot_info.bot_perfs_by_perf_type, expected_bot_perfs_by_perf_type)
 
   def test_get_online_bot_info_only_one_perf_played(self) -> None:
     lichess_client = FakeLichessClient()

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -184,6 +184,11 @@ class TestDataGeneratorFunctions(unittest.TestCase):
     ]
     self.assertCountEqual(updates, expected_updates)
 
+  def test_create_sort_key(self) -> None:
+    bot_names = ["BOT-4", "Bot-2", "Bot-5", "bot-3", "bot-1", "Bot-4", "Bot-1"]
+    sorted_bot_names = sorted(bot_names, key=lambda name: data_generator_functions.name_sort_key(name))
+    self.assertListEqual(sorted_bot_names, ["Bot-1", "bot-1", "Bot-2", "bot-3", "BOT-4", "Bot-4", "Bot-5"])
+
   def test_create_ranked_rows(self) -> None:
     updates: list[LeaderboardUpdate] = [
       CurrentBotPerfOnlyUpdate(BOT_2_PERF_BULLET),
@@ -262,11 +267,6 @@ class TestDataGeneratorFunctions(unittest.TestCase):
     bot_profiles_by_name = {"Bot-1": BotProfile("Bot-1", "", "", DATE_2021_04_01, DATE_2021_04_01, False, False, False, True)}
     leaderboard_rows = data_generator_functions.create_ranked_rows(updates, bot_profiles_by_name, DATE_2025_04_01)
     self.assertEqual(leaderboard_rows[0].rank_info.rank, 0)
-
-  def test_create_sort_key(self) -> None:
-    bot_names = ["BOT-4", "Bot-2", "Bot-5", "bot-3", "bot-1", "Bot-4", "Bot-1"]
-    sorted_bot_names = sorted(bot_names, key=lambda name: data_generator_functions.name_sort_key(name))
-    self.assertListEqual(sorted_bot_names, ["Bot-1", "bot-1", "Bot-2", "bot-3", "BOT-4", "Bot-4", "Bot-5"])
 
 
 class TestDataGenerator(unittest.TestCase):

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -150,6 +150,22 @@ class TestDataGeneratorFunctions(unittest.TestCase):
     )
     self.assertListEqual(bot_info.bot_perfs_by_perf_type[PerfType.BLITZ], [BOT_1_CURRENT_PERF_BLITZ, BOT_2_CURRENT_PERF_BLITZ])
 
+  def test_get_online_bot_info_only_one_perf_played(self) -> None:
+    lichess_client = FakeLichessClient()
+    lichess_client.set_online_bots(
+      """{ "username": "Bot-1", "perfs": { "bullet": { "games": 1000 }, "blitz": { "rating": 1500, "prov": true } } }"""
+    )
+    bot_info = data_generator_functions.get_online_bot_info(lichess_client)
+    self.assertListEqual(list(bot_info.bot_profiles_by_name.keys()), ["Bot-1"])
+    self.assertListEqual(list(bot_info.bot_perfs_by_perf_type.keys()), [PerfType.BULLET])
+
+  def test_get_online_bot_info_no_games_played(self) -> None:
+    lichess_client = FakeLichessClient()
+    lichess_client.set_online_bots("""{ "username": "Bot-1", "perfs": { "bullet": { "rating": 1500, "prov": true } } }""")
+    bot_info = data_generator_functions.get_online_bot_info(lichess_client)
+    self.assertDictEqual(bot_info.bot_profiles_by_name, {})
+    self.assertDictEqual(bot_info.bot_perfs_by_perf_type, {})
+
   def test_merge_bot_profiles(self) -> None:
     previous_profiles_by_name = {"Bot-1": BOT_1_PROFILE}
     current_profiles_by_name = {"Bot-1": BOT_1_CURRENT_PROFILE}

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -59,14 +59,14 @@ BOT_1_CURRENT_JSON = """
   "patron": true,
   "perfs": {
     "bullet": {
-        "games": 1100,
-        "rating": 2950,
-        "rd": 42,
-        "prog": -50
+      "games": 1100,
+      "rating": 2950,
+      "rd": 42,
+      "prog": -50
     },
     "blitz": {
-        "games": 100,
-        "rating": 2550
+      "games": 100,
+      "rating": 2550
     }
   }
 }
@@ -78,12 +78,12 @@ BOT_2_CURRENT_JSON = """
   "seenAt": 1743500000000,
   "perfs": {
     "bullet": {
-        "games": 1000,
-        "rating": 3000
+      "games": 1000,
+      "rating": 3000
     },
     "blitz": {
-        "games": 300,
-        "rating": 2500
+      "games": 300,
+      "rating": 2500
     }
   }
 }

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -1,5 +1,6 @@
 """Tests for data_generator.py."""
 
+import json
 import unittest
 
 from src.leaderboard.chrono.fixed_time_provider import FixedTimeProvider
@@ -112,8 +113,8 @@ class TestDataGeneratorFunctions(unittest.TestCase):
 
   def test_load_bot_profiles(self) -> None:
     file_system = InMemoryFileSystem()
-    bot_profiles = [BOT_1_CURRENT_PROFILE.to_json(), BOT_2_CURRENT_PROFILE.to_json()]
-    file_system.write_file(file_paths.bot_profiles_path(), "\n".join(bot_profiles))
+    bot_profiles = [BOT_1_CURRENT_PROFILE.as_dict(), BOT_2_CURRENT_PROFILE.as_dict()]
+    file_system.write_file(file_paths.bot_profiles_path(), json.dumps(bot_profiles))
     # When loading the bot profiles new and online are set to false
     expected_bot_profiles = {
       "Bot-1": BotProfile("Bot-1", "flair", "_earth", DATE_2024_04_01, DATE_2025_04_01, True, False, False, False),
@@ -129,10 +130,10 @@ class TestDataGeneratorFunctions(unittest.TestCase):
 
   def test_load_leaderboard_rows(self) -> None:
     file_system = InMemoryFileSystem()
-    bullet_leaderboard = [BOT_1_ROW_BULLET.to_json(), BOT_2_ROW_BULLET.to_json()]
-    blitz_leaderboard = [BOT_2_ROW_BLITZ.to_json(), BOT_1_ROW_BLITZ.to_json()]
-    file_system.write_file(file_paths.data_path(PerfType.BULLET), "\n".join(bullet_leaderboard))
-    file_system.write_file(file_paths.data_path(PerfType.BLITZ), "\n".join(blitz_leaderboard))
+    bullet_leaderboard = [BOT_1_ROW_BULLET.as_dict(), BOT_2_ROW_BULLET.as_dict()]
+    blitz_leaderboard = [BOT_2_ROW_BLITZ.as_dict(), BOT_1_ROW_BLITZ.as_dict()]
+    file_system.write_file(file_paths.data_path(PerfType.BULLET), json.dumps(bullet_leaderboard))
+    file_system.write_file(file_paths.data_path(PerfType.BLITZ), json.dumps(blitz_leaderboard))
     previous_rows_by_perf_type = data_generator_functions.load_leaderboard_rows(file_system)
     self.assertEqual(len(previous_rows_by_perf_type), 13)
     self.assertListEqual(previous_rows_by_perf_type[PerfType.BULLET], [BOT_1_ROW_BULLET, BOT_2_ROW_BULLET])
@@ -253,11 +254,11 @@ class TestDataGenerator(unittest.TestCase):
   def test_create_all_leaderboards(self) -> None:
     file_system = InMemoryFileSystem()
 
-    bullet_ndjson = [BOT_1_ROW_BULLET.to_json(), BOT_2_ROW_BULLET.to_json()]
-    file_system.write_file(file_paths.data_path(PerfType.BULLET), "\n".join(bullet_ndjson))
+    bullet_leaderboard_json = [BOT_1_ROW_BULLET.as_dict(), BOT_2_ROW_BULLET.as_dict()]
+    file_system.write_file(file_paths.data_path(PerfType.BULLET), json.dumps(bullet_leaderboard_json))
 
-    bot_profiles_json = [BOT_1_PROFILE.to_json(), BOT_2_PROFILE.to_json()]
-    file_system.write_file(file_paths.bot_profiles_path(), "\n".join(bot_profiles_json))
+    bot_profiles_json = [BOT_1_PROFILE.as_dict(), BOT_2_PROFILE.as_dict()]
+    file_system.write_file(file_paths.bot_profiles_path(), json.dumps(bot_profiles_json))
 
     lichess_client = FakeLichessClient()
     lichess_client.set_online_bots("\n".join([remove_whitespace(BOT_1_CURRENT_JSON), remove_whitespace(BOT_2_CURRENT_JSON)]))
@@ -273,8 +274,8 @@ class TestDataGenerator(unittest.TestCase):
     ]
     self.assertListEqual(leaderboard_data.get_ranked_rows_sorted()[PerfType.BULLET], expected_ranked_rows)
 
-    expected_bot_profiles = {
-      "Bot-1": BOT_1_CURRENT_PROFILE.create_updated_copy_for_for_merge(),
-      "Bot-2": BOT_2_CURRENT_PROFILE.create_updated_copy_for_for_merge(),
-    }
+    expected_bot_profiles = [
+      BOT_1_CURRENT_PROFILE.create_updated_copy_for_for_merge(),
+      BOT_2_CURRENT_PROFILE.create_updated_copy_for_for_merge(),
+    ]
     self.assertEqual(leaderboard_data.get_bot_profiles_sorted(), expected_bot_profiles)

--- a/tests/leaderboard/data/test_data_generator.py
+++ b/tests/leaderboard/data/test_data_generator.py
@@ -263,6 +263,11 @@ class TestDataGeneratorFunctions(unittest.TestCase):
     leaderboard_rows = data_generator_functions.create_ranked_rows(updates, bot_profiles_by_name, DATE_2025_04_01)
     self.assertEqual(leaderboard_rows[0].rank_info.rank, 0)
 
+  def test_create_sort_key(self) -> None:
+    bot_names = ["BOT-4", "Bot-2", "Bot-5", "bot-3", "bot-1", "Bot-4", "Bot-1"]
+    sorted_bot_names = sorted(bot_names, key=lambda name: data_generator_functions.name_sort_key(name))
+    self.assertListEqual(sorted_bot_names, ["Bot-1", "bot-1", "Bot-2", "bot-3", "BOT-4", "Bot-4", "Bot-5"])
+
 
 class TestDataGenerator(unittest.TestCase):
   """Tests for DataGenerator."""

--- a/tests/leaderboard/data/test_leaderboard_objects.py
+++ b/tests/leaderboard/data/test_leaderboard_objects.py
@@ -19,7 +19,7 @@ class TestBotProfile(unittest.TestCase):
       BotProfile("Bot1", "flair", "flag", DATE_2024_01_01, DATE_2025_04_01, True, True, True, True),
     )
 
-  def test_from_json_dict(self) -> None:
+  def test_from_dict(self) -> None:
     json_dict = {
       "name": "Bot1",
       "flair": "flair",
@@ -32,7 +32,7 @@ class TestBotProfile(unittest.TestCase):
       "online": True,
     }
     expected_bot_profile = BotProfile("Bot1", "flair", "FR", DATE_2024_01_01, DATE_2025_04_01, True, True, False, False)
-    self.assertEqual(BotProfile.from_json_dict(json_dict), expected_bot_profile)
+    self.assertEqual(BotProfile.from_dict(json_dict), expected_bot_profile)
 
   def test_create_updated_copy_for_for_merge(self) -> None:
     updated_copy = BotProfile("", "", "", 0, 0, False, False, True, True).create_updated_copy_for_for_merge()
@@ -48,8 +48,8 @@ class TestBotProfile(unittest.TestCase):
     bot_profile = BotProfile("", "", "", 0, DATE_2025_04_01, False, True, True, True)
     self.assertFalse(bot_profile.is_eligible(DATE_2025_04_01))
 
-  def test_from_json_dict_default(self) -> None:
-    self.assertEqual(BotProfile.from_json_dict({}), BotProfile("", "", "", 0, 0, False, False, False, False))
+  def test_from_dict_default(self) -> None:
+    self.assertEqual(BotProfile.from_dict({}), BotProfile("", "", "", 0, 0, False, False, False, False))
 
 
 class TestLeaderboardPerf(unittest.TestCase):
@@ -59,45 +59,37 @@ class TestLeaderboardPerf(unittest.TestCase):
     perf = Perf(PerfType.BULLET, 100, 1450, 25, -10, True)
     self.assertEqual(LeaderboardPerf.from_perf(perf), LeaderboardPerf(1450, 25, -10, 100, True))
 
-  def test_from_json_dict(self) -> None:
+  def test_from_dict(self) -> None:
     json_dict = {"rating": 1450, "rd": 25, "prog": -10, "games": 100, "prov": True}
-    self.assertEqual(LeaderboardPerf.from_json_dict(json_dict), LeaderboardPerf(1450, 25, -10, 100, True))
+    self.assertEqual(LeaderboardPerf.from_dict(json_dict), LeaderboardPerf(1450, 25, -10, 100, True))
 
-  def test_from_json_dict_default(self) -> None:
-    self.assertEqual(LeaderboardPerf.from_json_dict({}), LeaderboardPerf(0, 0, 0, 0, False))
+  def test_from_dict_default(self) -> None:
+    self.assertEqual(LeaderboardPerf.from_dict({}), LeaderboardPerf(0, 0, 0, 0, False))
 
 
 class TestLeaderboardRow(unittest.TestCase):
   """Tests for LeaderboardRow."""
 
-  def test_from_json(self) -> None:
-    leaderboard_row_json = """
-      {
-        "name": "Bot1",
-        "perf": {
-          "rating": 1700,
-          "rd": 115,
-          "prog": 15,
-          "games": 200,
-          "prov": true
-        },
-        "rank_info": {
-          "rank": 4,
-          "delta_rank": 1,
-          "delta_rating": 50,
-          "delta_games": 10,
-          "peak_rank": 3,
-          "peak_rating": 1700,
-          "last_played": 1743500000
-        }
-      }
-      """
+  def test_from_dict(self) -> None:
+    leaderboard_row_json_dict = {
+      "name": "Bot1",
+      "perf": {"rating": 1700, "rd": 115, "prog": 15, "games": 200, "prov": True},
+      "rank_info": {
+        "rank": 4,
+        "delta_rank": 1,
+        "delta_rating": 50,
+        "delta_games": 10,
+        "peak_rank": 3,
+        "peak_rating": 1700,
+        "last_played": 1743500000,
+      },
+    }
     expected_perf = LeaderboardPerf(1700, 115, 15, 200, True)
     expected_leaderboard_row = LeaderboardRow("Bot1", expected_perf, RankInfo(4, 1, 50, 10, 3, 1700, DATE_2025_04_01))
-    self.assertEqual(LeaderboardRow.from_json(leaderboard_row_json), expected_leaderboard_row)
+    self.assertEqual(LeaderboardRow.from_dict(leaderboard_row_json_dict), expected_leaderboard_row)
 
-  def test_to_json_round_trip(self) -> None:
+  def test_as_dict_round_trip(self) -> None:
     leaderboard_row = LeaderboardRow(
       "Bot1", LeaderboardPerf(1500, 12, 34, 100, True), RankInfo(4, 1, 50, 10, 3, 1600, DATE_2025_04_01)
     )
-    self.assertEqual(LeaderboardRow.from_json(leaderboard_row.to_json()), leaderboard_row)
+    self.assertEqual(LeaderboardRow.from_dict(leaderboard_row.as_dict()), leaderboard_row)

--- a/tests/leaderboard/fs/in_memory_file_system.py
+++ b/tests/leaderboard/fs/in_memory_file_system.py
@@ -8,12 +8,12 @@ class InMemoryFileSystem(FileSystem):
 
   def __init__(self) -> None:
     """Initialize a dict to represent the file system."""
-    self.file_system: dict[str, list[str]] = {}
+    self.file_system: dict[str, str] = {}
 
-  def load_file_lines(self, file_name: str) -> list[str]:
-    """Load and return all of the lines in a file."""
-    return self.file_system.get(file_name, [])
+  def read_file(self, file_name: str) -> str | None:
+    """Load and return all of the contents of a file."""
+    return self.file_system.get(file_name, "")
 
-  def save_file_lines(self, file_name: str, file_lines: list[str]) -> None:
-    """Save all of the lines to a file."""
-    self.file_system[file_name] = file_lines
+  def write_file(self, file_name: str, file_contents: str) -> None:
+    """Save the contents to a file."""
+    self.file_system[file_name] = file_contents

--- a/tests/leaderboard/fs/test_file_paths.py
+++ b/tests/leaderboard/fs/test_file_paths.py
@@ -10,7 +10,7 @@ class TestFileFilePaths(unittest.TestCase):
   """Tests for file_paths."""
 
   def test_data_path(self) -> None:
-    self.assertEqual(file_paths.data_path(PerfType.BULLET), "leaderboard_data/bullet.ndjson")
+    self.assertEqual(file_paths.data_path(PerfType.BULLET), "leaderboard_data/bullet.json")
 
   def test_html_path(self) -> None:
     self.assertEqual(file_paths.html_path("index"), "leaderboard_html/index.html")

--- a/tests/leaderboard/fs/test_file_system.py
+++ b/tests/leaderboard/fs/test_file_system.py
@@ -6,7 +6,7 @@ from tests.leaderboard.fs.in_memory_file_system import InMemoryFileSystem
 
 
 FILE_NAME = "test"
-FILE_LINES = ["1", "2", "3"]
+FILE_LINES = "1\n2\n3"
 
 
 class TestFileSystem(unittest.TestCase):
@@ -14,5 +14,5 @@ class TestFileSystem(unittest.TestCase):
 
   def test_save_and_load(self) -> None:
     file_system = InMemoryFileSystem()
-    file_system.save_file_lines(FILE_NAME, FILE_LINES)
-    self.assertListEqual(file_system.load_file_lines(FILE_NAME), FILE_LINES)
+    file_system.write_file(FILE_NAME, FILE_LINES)
+    self.assertEqual(file_system.read_file(FILE_NAME), FILE_LINES)

--- a/tests/leaderboard/li/test_bot_user.py
+++ b/tests/leaderboard/li/test_bot_user.py
@@ -19,17 +19,17 @@ BOT_USER_JSON = """
   "patron": true,
   "perfs": {
     "bullet": {
-        "games": 123,
-        "rating": 1450
+      "games": 123,
+      "rating": 1450
     },
     "blitz": {
-        "games": 456,
-        "rating": 1500
+      "games": 456,
+      "rating": 1500
     },
     "rapid": {
-        "games": 789,
-        "rating": 1550,
-        "prov": true
+      "games": 789,
+      "rating": 1550,
+      "prov": true
     }
   }
 }

--- a/tests/leaderboard/main/test_leaderboard_generator.py
+++ b/tests/leaderboard/main/test_leaderboard_generator.py
@@ -25,8 +25,12 @@ class TestLeaderboardGenerator(unittest.TestCase):
     leaderboard_generator = LeaderboardGenerator(file_system, lichess_client, time_provider, log_writer)
     leaderboard_generator.generate_leaderboards()
 
-    bullet_data = file_system.load_file_lines(file_paths.data_path(PerfType.BULLET))
-    self.assertIn("Bot-1", bullet_data[0])
+    bullet_data = file_system.read_file(file_paths.data_path(PerfType.BULLET))
+    if not bullet_data:
+      self.fail(f"Missing bullet_data: {bullet_data}")
+    self.assertIn("Bot-1", bullet_data)
 
-    bullet_html = file_system.load_file_lines(file_paths.html_path(PerfType.BULLET.to_string()))
-    self.assertIn("Bot-1", bullet_html[0])
+    bullet_html = file_system.read_file(file_paths.html_path(PerfType.BULLET.to_string()))
+    if not bullet_html:
+      self.fail(f"Missing bullet_html: {bullet_html}")
+    self.assertIn("Bot-1", bullet_html)

--- a/tests/leaderboard/main/test_leaderboard_generator.py
+++ b/tests/leaderboard/main/test_leaderboard_generator.py
@@ -20,7 +20,7 @@ class TestLeaderboardGenerator(unittest.TestCase):
     time_provider = FixedTimeProvider(0)
     log_writer = FakeLogWriter()
 
-    lichess_client.set_online_bots("""{ "username": "Bot-1", "perfs": { "bullet": { "rating": 2345 } } }""")
+    lichess_client.set_online_bots("""{ "username": "Bot-1", "perfs": { "bullet": { "rating": 2345, "games": 678 } } }""")
 
     leaderboard_generator = LeaderboardGenerator(file_system, lichess_client, time_provider, log_writer)
     leaderboard_generator.generate_leaderboards()

--- a/tests/leaderboard/main/test_leaderboard_generator.py
+++ b/tests/leaderboard/main/test_leaderboard_generator.py
@@ -5,10 +5,22 @@ import unittest
 from src.leaderboard.chrono.fixed_time_provider import FixedTimeProvider
 from src.leaderboard.fs import file_paths
 from src.leaderboard.li.pert_type import PerfType
+from src.leaderboard.main import leaderboard_generator as leaderboard_generation_functions
 from src.leaderboard.main.leaderboard_generator import LeaderboardGenerator
 from tests.leaderboard.fs.in_memory_file_system import InMemoryFileSystem
 from tests.leaderboard.li.fake_lichess_client import FakeLichessClient
 from tests.leaderboard.log.fake_log_writer import FakeLogWriter
+
+
+class TestLeaderboardGeneratorFunctions(unittest.TestCase):
+  """Tests for leaderboard generator functions."""
+
+  def test_increment_generation_number(self) -> None:
+    file_system = InMemoryFileSystem()
+    leaderboard_generation_functions.increment_generation_number(file_system)
+    self.assertEqual(file_system.read_file(file_paths.generation_number_path()), "1")
+    leaderboard_generation_functions.increment_generation_number(file_system)
+    self.assertEqual(file_system.read_file(file_paths.generation_number_path()), "2")
 
 
 class TestLeaderboardGenerator(unittest.TestCase):

--- a/tests/leaderboard/page/test_html_generator.py
+++ b/tests/leaderboard/page/test_html_generator.py
@@ -11,8 +11,8 @@ from tests.leaderboard.chrono import epoch_seconds
 
 
 DEFAULT_BOT_PROFILES_BY_NAME = {
-  "Bot-1": BotProfile.from_json('{"name": "Bot-1"}'),
-  "Bot-2": BotProfile.from_json('{"name": "Bot-2"}'),
+  "Bot-1": BotProfile.from_dict({"name": "Bot-1"}),
+  "Bot-2": BotProfile.from_dict({"name": "Bot-2"}),
 }
 
 DATE_2024_10_31 = epoch_seconds.from_date(2024, 10, 31)


### PR DESCRIPTION
This also
 - Refactors the file system interface
 - Makes it so bot data is only saved if it has at least one game played
 - Adds further subsorting for leaderboard rows and data
 - Updates prettierignore to exclude leaderboard data (which is now json)
 - Adds a ci job to ensure no leaderboard data is added to main
 - Significantly improves nav link wrapping
 - Adds tracking for how many times the leaderboard has been generated
 - Updates some comments and similar minor changes